### PR TITLE
[Feat] CAU 소프트웨어학부 멀티 게시판 크롤링 지원 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "test:dept": "node --loader ts-node/esm scripts/test-dept-crawler.ts"
+    "test:dept": "node --loader ts-node/esm scripts/test-dept-crawler.ts",
+    "test:cau": "node --loader ts-node/esm scripts/test-cau-board.ts"
   },
   "keywords": [],
   "author": "",

--- a/scripts/test-cau-board.ts
+++ b/scripts/test-cau-board.ts
@@ -1,0 +1,57 @@
+// Test runner for the CAU CSE boards.
+// Usage: npm run test:cau sub0501|sub0502|sub0506
+
+import { deptCrawler } from "../src/integrations/cau/deptCrawler.js";
+import type { SiteConfig } from "../src/types/config.js";
+
+type BoardName = "sub0501" | "sub0502" | "sub0506";
+
+const BASE_URL = "https://cse.cau.ac.kr";
+
+const boardConfig: Record<BoardName, { listPath: string }> = {
+  sub0501: { listPath: "/sub05/sub0501.php" },
+  sub0502: { listPath: "/sub05/sub0502.php" },
+  sub0506: { listPath: "/sub05/sub0506.php" },
+};
+
+const sharedSelectors: NonNullable<SiteConfig["selectors"]> = {
+  item: "table.table-basic tr",
+  title: "td.aleft a",
+  url: "td.aleft a",
+  date: "td.pc-only",
+};
+
+function buildSiteConfig(board: BoardName): SiteConfig {
+  const { listPath } = boardConfig[board];
+
+  return {
+    // We reuse the existing CAU department source ID; the board
+    // differentiation is done via listPath and the CLI argument.
+    id: "cau_dept",
+    baseUrl: BASE_URL,
+    listPath,
+    selectors: sharedSelectors,
+  };
+}
+
+async function main() {
+  const arg = process.argv[2] as BoardName | undefined;
+
+  if (!arg || !(arg in boardConfig)) {
+    // eslint-disable-next-line no-console
+    console.error(
+      'Usage: npm run test:cau <sub0501|sub0502|sub0506>'
+    );
+    process.exit(1);
+  }
+
+  const site = buildSiteConfig(arg);
+  const result = await deptCrawler.crawl(site);
+
+  // Pretty-print the crawl result as JSON.
+  // eslint-disable-next-line no-console
+  console.log(JSON.stringify(result, null, 2));
+}
+
+void main();
+

--- a/scripts/test-dept-crawler.ts
+++ b/scripts/test-dept-crawler.ts
@@ -4,31 +4,14 @@
 // - Logs the returned notices to the console
 
 import { deptCrawler } from "../src/integrations/cau/deptCrawler.js";
-import type { SiteConfig } from "../src/types/config.js";
+import { cauBoards } from "../src/integrations/cau/boards.js";
 
 async function main() {
-  const site: SiteConfig = {
-    id: "cau_dept",
-    baseUrl: "https://cse.cau.ac.kr",
-    listPath: "/sub05/sub0501.php",
-    selectors: {
-      // The notice list rows live inside the main board table.
-      // Cheerio does not auto-insert <tbody>, so we match all rows.
-      item: "table.table-basic tr",
-      // The title link is inside the "aleft" column.
-      title: "td.aleft a",
-      url: "td.aleft a",
-      // All date-like cells share the pc-only class; the crawler
-      // will choose the one that looks like a YYYY.MM.DD date.
-      date: "td.pc-only",
-    },
-  };
-
-  const result = await deptCrawler.crawl(site);
-
-  // For quick inspection, log notices as JSON.
-  // eslint-disable-next-line no-console
-  console.log(JSON.stringify(result.notices, null, 2));
+  for (const board of cauBoards) {
+    const result = await deptCrawler.crawl(board);
+    // eslint-disable-next-line no-console
+    console.log(board.id, result.notices.length);
+  }
 }
 
 void main();

--- a/src/integrations/cau/boards.ts
+++ b/src/integrations/cau/boards.ts
@@ -1,0 +1,34 @@
+// Configuration for CAU CSE boards that share the same HTML structure.
+
+import type { SiteConfig } from "../../types/config.js";
+
+const BASE_URL = "https://cse.cau.ac.kr";
+
+const sharedSelectors: NonNullable<SiteConfig["selectors"]> = {
+  item: "table.table-basic tr",
+  title: "td.aleft a",
+  url: "td.aleft a",
+  date: "td.pc-only",
+};
+
+export const cauBoards: SiteConfig[] = [
+  {
+    id: "cau_notice",
+    baseUrl: BASE_URL,
+    listPath: "/sub05/sub0501.php",
+    selectors: sharedSelectors,
+  },
+  {
+    id: "cau_job",
+    baseUrl: BASE_URL,
+    listPath: "/sub05/sub0502.php",
+    selectors: sharedSelectors,
+  },
+  {
+    id: "cau_contest",
+    baseUrl: BASE_URL,
+    listPath: "/sub05/sub0506.php",
+    selectors: sharedSelectors,
+  },
+];
+


### PR DESCRIPTION
## 📌 변경 사항
- CAU 소프트웨어학부 멀티 게시판 크롤링 지원 확장
  - sub0501 (공지사항&뉴스)
  - sub0502 (취업정보)
  - sub0506 (공모전 소식)
- 게시판별 code 값 분리 처리 (oktomato_bbs05 / 07 / 06)
- 공통 selector 기반 재사용 구조 유지
- 테스트 스크립트 개선
  - scripts/test-cau-board.ts
  - CLI 인자로 게시판 선택 가능
- 각 게시판별 크롤링 결과 검증 완료

---

## 🎯 결과
- 3개 게시판 모두 정상 수집 확인
- title / url / publishedAt 파싱 정상 동작
- NEW 태그 제거 및 날짜 파싱 로직 재사용
- 구조 변경 없이 확장 가능성 확보

---

## 🧱 구조적 의미
- 단일 크롤러 → 설정 기반 멀티 게시판 확장 완료
- 이후 타 학과/타 사이트 확장 가능 구조 마련
- 이메일 알림 및 날짜 필터 연결 준비 단계 완료

---

## 🚀 다음 단계
- 7일 이내 게시물 필터링 로직 연결
- 이메일 알림 기능 구현
- GitHub Actions 주간 실행 자동화