### PR TITLE
[Feat] 최근 N일 게시물 필터(dateFilter) 유틸리티 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "test:dept": "node --loader ts-node/esm scripts/test-dept-crawler.ts",
-    "test:cau": "node --loader ts-node/esm scripts/test-cau-board.ts"
+    "test:cau": "node --loader ts-node/esm scripts/test-cau-board.ts",
+    "test:date": "node --loader ts-node/esm scripts/test-date-filter.ts"
   },
   "keywords": [],
   "author": "",

--- a/scripts/test-date-filter.ts
+++ b/scripts/test-date-filter.ts
@@ -1,0 +1,59 @@
+// Manual test runner for filterRecentNotices.
+// Usage: npm run test:date
+
+import type { Notice } from "../src/types/notice.js";
+import { filterRecentNotices } from "../src/core/filters/dateFilter.js";
+
+function daysAgo(n: number): Date {
+  const now = new Date();
+  const msInDay = 24 * 60 * 60 * 1000;
+  return new Date(now.getTime() - n * msInDay);
+}
+
+async function main() {
+  const notices: Notice[] = [
+    {
+      id: "within-2-days",
+      title: "Notice within 2 days",
+      url: "https://example.com/within-2-days",
+      publishedAt: daysAgo(2),
+      source: "cau_dept",
+    },
+    {
+      id: "eight-days-old",
+      title: "Notice 8 days old",
+      url: "https://example.com/eight-days-old",
+      publishedAt: daysAgo(8),
+      source: "cau_dept",
+    },
+    {
+      id: "exactly-7-days",
+      title: "Notice exactly 7 days old",
+      url: "https://example.com/exactly-7-days",
+      publishedAt: daysAgo(7),
+      source: "cau_dept",
+    },
+    {
+      id: "invalid-date",
+      title: "Notice with invalid date",
+      url: "https://example.com/invalid-date",
+      publishedAt: new Date("invalid" as unknown as string),
+      source: "cau_dept",
+    },
+  ];
+
+  const filtered = filterRecentNotices(notices, 7);
+
+  // eslint-disable-next-line no-console
+  console.log("Original count:", notices.length);
+  // eslint-disable-next-line no-console
+  console.log("Filtered count:", filtered.length);
+  // eslint-disable-next-line no-console
+  console.log(
+    "Filtered IDs:",
+    filtered.map((n) => n.id)
+  );
+}
+
+void main();
+

--- a/src/core/filters/dateFilter.ts
+++ b/src/core/filters/dateFilter.ts
@@ -1,0 +1,31 @@
+// Pure utility for filtering notices to those within the last N days.
+
+import type { Notice } from "../../types/notice.js";
+
+export function filterRecentNotices(
+  notices: Notice[],
+  days: number = 7
+): Notice[] {
+  if (!Number.isFinite(days) || days <= 0) {
+    return [];
+  }
+
+  const now = new Date();
+  const msInDay = 24 * 60 * 60 * 1000;
+  const thresholdTime = now.getTime() - days * msInDay;
+
+  return notices.filter((notice) => {
+    const publishedAt = notice.publishedAt;
+    if (!(publishedAt instanceof Date)) {
+      return false;
+    }
+
+    const time = publishedAt.getTime();
+    if (!Number.isFinite(time)) {
+      return false;
+    }
+
+    return time >= thresholdTime;
+  });
+}
+


### PR DESCRIPTION
## 📌 변경 사항
- 최근 N일 게시물 필터 유틸리티 filterRecentNotices 추가
- src/core/filters/dateFilter.ts 신규 생성
- publishedAt 기준 날짜 비교 로직 구현
- 원본 배열을 변경하지 않는 순수 함수 형태로 작성

---

## 🎯 동작 방식
- 기준 시각: now - days
- publishedAt >= threshold 인 게시물만 반환
- publishedAt이 없거나 유효하지 않은 경우 제외
- 기본값: 최근 7일

---

## 🧱 아키텍처 의도
- 크롤러와 분리된 순수 비즈니스 레이어 구현
- 이후 이메일 발송 로직 이전에 체이닝하여 사용 예정
- 테스트 및 재사용 가능하도록 side-effect 없는 구조 유지

---

## 🚀 다음 단계
- weeklyNoticeJob에 dateFilter 연결
- 이메일 전송 로직 연동
- GitHub Actions 자동화