### PR TITLE
[Feat] Gmail SMTP 기반 이메일 알림 기능 구현 및 테스트 스크립트 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,8 @@
       },
       "devDependencies": {
         "@types/node": "^25.2.3",
+        "@types/nodemailer": "^7.0.9",
+        "dotenv": "^17.2.4",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3"
       }
@@ -98,6 +100,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-7.0.9.tgz",
+      "integrity": "sha512-vI8oF1M+8JvQhsId0Pc38BdUP2evenIIys7c7p+9OZXSPOH5c1dyINP1jT8xQ2xPuBUXmIC87s+91IZMDjH8Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/acorn": {
@@ -336,6 +348,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.4",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.4.tgz",
+      "integrity": "sha512-mudtfb4zRB4bVvdj0xRo+e6duH1csJRM8IukBqfTRvHotn9+LBXB8ynAidP9zHqoRC/fsllXgk4kCKlR21fIhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test:dept": "node --loader ts-node/esm scripts/test-dept-crawler.ts",
     "test:cau": "node --loader ts-node/esm scripts/test-cau-board.ts",
     "test:date": "node --loader ts-node/esm scripts/test-date-filter.ts",
-    "test:pipeline": "node --loader ts-node/esm scripts/test-cau-pipeline.ts"
+    "test:pipeline": "node --loader ts-node/esm scripts/test-cau-pipeline.ts",
+    "test:mail": "node --loader ts-node/esm scripts/test-mail.ts"
   },
   "keywords": [],
   "author": "",
@@ -23,6 +24,8 @@
   },
   "devDependencies": {
     "@types/node": "^25.2.3",
+    "@types/nodemailer": "^7.0.9",
+    "dotenv": "^17.2.4",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"
   }

--- a/scripts/test-mail.ts
+++ b/scripts/test-mail.ts
@@ -1,0 +1,13 @@
+// Test runner for mail sender.
+// Usage: npm run test:mail
+
+import "dotenv/config";
+import { sendMail } from "../src/core/mail/mailSender.js";
+
+async function main() {
+  await sendMail("테스트 메일입니다", "이것은 테스트 메일입니다.");
+  // eslint-disable-next-line no-console
+  console.log("메일 전송 완료");
+}
+
+void main();

--- a/src/core/mail/mailSender.ts
+++ b/src/core/mail/mailSender.ts
@@ -1,0 +1,25 @@
+// Gmail SMTP-based mail sender using nodemailer.
+
+import nodemailer from "nodemailer";
+import { requireEnv } from "../../utils/env.js";
+
+export async function sendMail(subject: string, text: string): Promise<void> {
+  const smtpUser = requireEnv("SMTP_USER");
+  const smtpPass = requireEnv("SMTP_PASS");
+  const mailTo = requireEnv("MAIL_TO");
+
+  const transporter = nodemailer.createTransport({
+    service: "gmail",
+    auth: {
+      user: smtpUser,
+      pass: smtpPass,
+    },
+  });
+
+  await transporter.sendMail({
+    from: `CAU Notice Bot <${smtpUser}>`,
+    to: mailTo,
+    subject,
+    text,
+  });
+}


### PR DESCRIPTION
## 📌 변경 사항
- nodemailer 기반 이메일 전송 모듈 구현
- Gmail SMTP(App Password) 인증 방식 적용
- 환경변수 기반 계정/비밀번호 설정
- 테스트 스크립트 scripts/test-mail.ts 추가
- Gmail → Naver 수신 정상 동작 검증 완료

---

## 🎯 결과
- SMTP 연결 성공
- 실제 외부 메일 수신 성공
- 콘솔 로그 메일 전송 완료 확인
- 향후 파이프라인과 연결 가능한 상태

---

## 🚀 다음 단계
- 크롤링 파이프라인 결과와 이메일 모듈 연결
- HTML 기반 공지 목록 템플릿 구성
- GitHub Actions에서 자동 실행 연결