### PR TITLE
[Feat] CAU 크롤링 파이프라인과 이메일 발송 기능 통합

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test:pipeline": "node --loader ts-node/esm scripts/test-cau-pipeline.ts",
     "test:mail": "node --loader ts-node/esm scripts/test-mail.ts",
     "test:email-template": "node --loader ts-node/esm scripts/test-email-template.ts",
-    "test:email-pipeline": "node --loader ts-node/esm scripts/test-email-pipeline.ts"
+    "test:email-pipeline": "node --loader ts-node/esm scripts/test-email-pipeline.ts",
+    "start:bot": "node --loader ts-node/esm src/app/runCauNoticeBot.ts"
   },
   "keywords": [],
   "author": "",

--- a/scripts/test-mail.ts
+++ b/scripts/test-mail.ts
@@ -5,7 +5,18 @@ import "dotenv/config";
 import { sendMail } from "../src/core/mail/mailSender.js";
 
 async function main() {
-  await sendMail("테스트 메일입니다", "이것은 테스트 메일입니다.");
+  const testHtml = `
+    <div style="font-family: Arial, sans-serif;">
+      <h2>테스트 메일입니다</h2>
+      <p>이것은 <strong>HTML</strong> 형식의 테스트 메일입니다.</p>
+      <ul>
+        <li>항목 1</li>
+        <li>항목 2</li>
+      </ul>
+    </div>
+  `;
+  
+  await sendMail("테스트 메일입니다", testHtml);
   // eslint-disable-next-line no-console
   console.log("메일 전송 완료");
 }

--- a/src/app/runCauNoticeBot.ts
+++ b/src/app/runCauNoticeBot.ts
@@ -1,0 +1,89 @@
+// Production runner for the CAU notice bot.
+// Orchestrates: crawling → filtering → email generation → sending.
+
+import "dotenv/config";
+import { deptCrawler } from "../integrations/cau/deptCrawler.js";
+import type { SiteConfig } from "../types/config.js";
+import type { Notice } from "../types/notice.js";
+import { filterRecentNotices } from "../core/filters/dateFilter.js";
+import { buildCauNoticeEmail } from "../integrations/email/templates/cauNoticeTemplate.js";
+import { sendMail } from "../core/mail/mailSender.js";
+
+const boards = ["sub0501", "sub0502", "sub0506"] as const;
+
+const BASE_URL = "https://cse.cau.ac.kr";
+
+const boardConfig = {
+  sub0501: { listPath: "/sub05/sub0501.php" },
+  sub0502: { listPath: "/sub05/sub0502.php" },
+  sub0506: { listPath: "/sub05/sub0506.php" },
+};
+
+const sharedSelectors: NonNullable<SiteConfig["selectors"]> = {
+  item: "table.table-basic tr",
+  title: "td.aleft a",
+  url: "td.aleft a",
+  date: "td.pc-only",
+};
+
+function buildSiteConfig(board: typeof boards[number]): SiteConfig {
+  return {
+    id: "cau_dept",
+    baseUrl: BASE_URL,
+    listPath: boardConfig[board].listPath,
+    selectors: sharedSelectors,
+  };
+}
+
+function boardIdResolver(notice: Notice): "sub0501" | "sub0502" | "sub0506" {
+  if (notice.url.includes("bbs05")) return "sub0501";
+  if (notice.url.includes("bbs07")) return "sub0502";
+  if (notice.url.includes("bbs06")) return "sub0506";
+  return "sub0501";
+}
+
+async function main() {
+  try {
+    // 1. Crawl all boards sequentially
+    const allNotices: Notice[] = [];
+    
+    for (const board of boards) {
+      const site = buildSiteConfig(board);
+      const result = await deptCrawler.crawl(site);
+      if (result.notices && Array.isArray(result.notices)) {
+        allNotices.push(...result.notices);
+      }
+    }
+
+    // eslint-disable-next-line no-console
+    console.log(`Total merged count: ${allNotices.length}`);
+
+    // 2. Apply 7-day filter
+    const recent = filterRecentNotices(allNotices, 7);
+
+    // eslint-disable-next-line no-console
+    console.log(`Filtered count (7 days): ${recent.length}`);
+
+    // 3. Exit if no recent notices
+    if (recent.length === 0) {
+      // eslint-disable-next-line no-console
+      console.log("No recent notices found. Exiting without sending email.");
+      return;
+    }
+
+    // 4. Build email
+    const email = buildCauNoticeEmail(recent, boardIdResolver);
+
+    // 5. Send email
+    await sendMail(email.subject, email.html);
+
+    // eslint-disable-next-line no-console
+    console.log("✅ Email sent successfully.");
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error("❌ Error running CAU notice bot:", error);
+    process.exit(1);
+  }
+}
+
+void main();

--- a/src/core/mail/mailSender.ts
+++ b/src/core/mail/mailSender.ts
@@ -3,7 +3,7 @@
 import nodemailer from "nodemailer";
 import { requireEnv } from "../../utils/env.js";
 
-export async function sendMail(subject: string, text: string): Promise<void> {
+export async function sendMail(subject: string, html: string): Promise<void> {
   const smtpUser = requireEnv("SMTP_USER");
   const smtpPass = requireEnv("SMTP_PASS");
   const mailTo = requireEnv("MAIL_TO");
@@ -16,10 +16,17 @@ export async function sendMail(subject: string, text: string): Promise<void> {
     },
   });
 
+  // Generate a simple plain text fallback by stripping HTML tags
+  const text = html
+    .replace(/<[^>]*>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
   await transporter.sendMail({
     from: `CAU Notice Bot <${smtpUser}>`,
     to: mailTo,
     subject,
     text,
+    html,
   });
 }


### PR DESCRIPTION
## 📌 변경 사항
- CAU 다중 게시판 크롤링 파이프라인 완성
  - sub0501 / sub0502 / sub0506 병합
  - filterRecentNotices(7일) 적용
- 이메일 템플릿과 실제 발송 로직 통합
- nodemailer 기반 Gmail SMTP 연동
- HTML + text fallback 포함

---

## 🎯 결과
- 실제 크롤링된 공지가 포함된 이메일 정상 발송 확인
- 게시판별 그룹화 유지
- 7일 필터 정확히 적용
- 링크 클릭 시 상세 페이지 정상 이동

---

## 🧩 현재 구조

crawlAllCauBoards()
→ merge
→ filterRecentNotices(7)
→ buildCauNoticeEmail()
→ sendMail()

---

## 🚀 다음 단계
- GitHub Actions 스케줄링 자동화
- production 환경변수 분리