### PR TITLE
[Feat] CAU Notice Bot 주간 크론 스케줄러(GitHub Actions) 추가

### DIFF
--- a/.github/workflows/weekly-notice.yml
+++ b/.github/workflows/weekly-notice.yml
@@ -2,7 +2,9 @@ name: Weekly CAU Notices
 
 on:
   schedule:
-    - cron: "0 0 * * 0"
+    # Run every Friday at 9:00 AM KST (00:00 UTC)
+    # KST = UTC+9, so 9:00 KST = 00:00 UTC
+    - cron: "0 0 * * 5"
   workflow_dispatch:
 
 jobs:
@@ -13,7 +15,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Use Node.js
+      - name: Setup Node.js v20
         uses: actions/setup-node@v4
         with:
           node-version: "20"
@@ -21,14 +23,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
-        run: npm run build --if-present
-
-      - name: Run weekly notice job
+      - name: Run CAU Notice Bot
         env:
-          # TODO: configure required email and other secrets in GitHub repo settings.
-          # EXAMPLE_SMTP_USER: ${{ secrets.EXAMPLE_SMTP_USER }}
-          # EXAMPLE_SMTP_PASS: ${{ secrets.EXAMPLE_SMTP_PASS }}
-          NODE_ENV: production
-        run: node dist/index.js
+          SMTP_USER: ${{ secrets.EMAIL_USER }}
+          SMTP_PASS: ${{ secrets.EMAIL_PASS }}
+          MAIL_TO: ${{ secrets.EMAIL_TO }}
+        run: npm run start
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:mail": "node --loader ts-node/esm scripts/test-mail.ts",
     "test:email-template": "node --loader ts-node/esm scripts/test-email-template.ts",
     "test:email-pipeline": "node --loader ts-node/esm scripts/test-email-pipeline.ts",
+    "start": "node --loader ts-node/esm src/app/runCauNoticeBot.ts",
     "start:bot": "node --loader ts-node/esm src/app/runCauNoticeBot.ts",
     "clean:cache": "rm -rf dist .ts-node node_modules/.cache"
   },


### PR DESCRIPTION
## 📌 변경 사항
- GitHub Actions 기반 주간 자동 실행 워크플로우 추가
  - .github/workflows/weekly-notice.yml 생성 
  - 매주 금요일 오전 9시(KST, UTC 00:00) cron 설정
- node dist/index.js 직접 실행 제거
- npm run start 기반 실행 구조로 통일
- EMAIL_USER / EMAIL_PASS / EMAIL_TO GitHub Secrets 연동
- workflow_dispatch 추가 (수동 실행 지원)

---

## 🎯 결과
- 서버 없이 GitHub Actions에서 자동 실행 가능
- 매주 금요일 오전 9시 자동 메일 발송 구조 완성
- 수동 실행으로 즉시 테스트 가능
- 환경변수는 GitHub Secrets로 안전하게 관리

---

## 🧩 현재 구조

GitHub Actions (cron)
→ npm ci
→ npm run start
→ crawlAllCauBoards()
→ filterRecentNotices(7)
→ buildCauNoticeEmail()
→ sendMail()

---

## 🚀 다음 단계
- 수신자 리스트 분리 (환경변수 → 설정 파일 분리)
- 장애 대비 로그 강화
- 중앙대 포탈 공지사항 추가