### PR TITLE
[Feat] 사이트 장애 fallback 및 전체 실패 재시도 추가

### DIFF
--- a/src/app/runCauNoticeBot.ts
+++ b/src/app/runCauNoticeBot.ts
@@ -9,7 +9,7 @@ import type { Notice } from "../types/notice.js";
 import { filterRecentNotices } from "../core/filters/dateFilter.js";
 import { buildUnifiedNoticeEmail } from "../integrations/email/templates/cauNoticeTemplate.js";
 import { sendMail } from "../core/mail/mailSender.js";
-import { info, error } from "../utils/logger.js";
+import { info, warn, error } from "../utils/logger.js";
 import { loadRecipients } from "../config/loadRecipients.js";
 
 const boards = ["sub0501", "sub0502", "sub0506"] as const;
@@ -37,6 +37,9 @@ const swEduSelectors: NonNullable<SiteConfig["selectors"]> = {
   date: "td",
 };
 
+const PIPELINE_MAX_RETRIES = 3;
+const PIPELINE_RETRY_DELAY_MS = 3000;
+
 function buildSiteConfig(board: typeof boards[number]): SiteConfig {
   return {
     id: "cau_dept",
@@ -55,36 +58,80 @@ function buildSwEduSiteConfig(): SiteConfig {
   };
 }
 
-async function main() {
-  try {
-    info("📚 Crawling Department boards...");
-    
-    const deptNotices: Notice[] = [];
-    for (const board of boards) {
+type CrawlAttemptResult = {
+  notices: Notice[];
+  successSources: string[];
+  failedSources: string[];
+};
+
+async function crawlAllSourcesOnce(): Promise<CrawlAttemptResult> {
+  const notices: Notice[] = [];
+  const successSources: string[] = [];
+  const failedSources: string[] = [];
+
+  info("📚 Crawling Department boards...");
+  for (const board of boards) {
+    try {
       const site = buildSiteConfig(board);
       const result = await deptCrawler.crawl(site);
       if (result.notices && Array.isArray(result.notices)) {
-        deptNotices.push(...result.notices);
+        notices.push(...result.notices);
+      }
+      successSources.push(`cau_dept:${board}`);
+    } catch (err) {
+      failedSources.push(`cau_dept:${board}`);
+      warn(`⚠️ Crawl failed for cau_dept:${board}`, err);
+    }
+  }
+
+  info("🎓 Crawling SW Education Institute...");
+  try {
+    const swEduSite = buildSwEduSiteConfig();
+    const swEduResult = await swEduCrawler.crawl(swEduSite);
+    if (swEduResult.notices && Array.isArray(swEduResult.notices)) {
+      notices.push(...swEduResult.notices);
+    }
+    successSources.push("cau_sw_edu");
+  } catch (err) {
+    failedSources.push("cau_sw_edu");
+    warn("⚠️ Crawl failed for cau_sw_edu", err);
+  }
+
+  return { notices, successSources, failedSources };
+}
+
+async function main() {
+  try {
+    let allNotices: Notice[] = [];
+    let successSources: string[] = [];
+    let failedSources: string[] = [];
+
+    for (let attempt = 1; attempt <= PIPELINE_MAX_RETRIES; attempt++) {
+      const result = await crawlAllSourcesOnce();
+      allNotices = result.notices;
+      successSources = result.successSources;
+      failedSources = result.failedSources;
+
+      if (successSources.length > 0) {
+        break;
+      }
+
+      if (attempt < PIPELINE_MAX_RETRIES) {
+        warn(
+          `⚠️ All sources failed on attempt ${attempt}/${PIPELINE_MAX_RETRIES}. Retrying in ${PIPELINE_RETRY_DELAY_MS}ms...`
+        );
+        await new Promise((resolve) => setTimeout(resolve, PIPELINE_RETRY_DELAY_MS));
       }
     }
 
-    info(`✅ Dept count: ${deptNotices.length}`);
-
-    info("🎓 Crawling SW Education Institute...");
-    const swEduSite = buildSwEduSiteConfig();
-    const swEduResult = await swEduCrawler.crawl(swEduSite);
-
-    const swEduNotices: Notice[] = [];
-    if (swEduResult.notices && Array.isArray(swEduResult.notices)) {
-      swEduNotices.push(...swEduResult.notices);
+    if (successSources.length === 0) {
+      throw new Error(`All crawl sources failed after ${PIPELINE_MAX_RETRIES} attempts`);
     }
 
-    info(`✅ SW Edu count: ${swEduNotices.length}`);
-
-    const allNotices: Notice[] = [
-      ...deptNotices,
-      ...swEduNotices,
-    ];
+    info(`✅ Successful sources: ${successSources.length}`);
+    if (failedSources.length > 0) {
+      warn(`⚠️ Failed sources: ${failedSources.join(", ")}`);
+    }
 
     info(`📊 Total merged count: ${allNotices.length}`);
 


### PR DESCRIPTION
## 📌 변경 사항
- 소스별 크롤링을 분리하여 개별 실패 격리
- 일부 소스 실패 시 성공 소스 데이터로 메일 발송 지속
- 전체 소스 실패 시 최대 3회 재시도(3초 간격)
- 성공/실패 소스 요약 로그 추가
- 기존 필터/템플릿/메일 전송 로직은 유지
---

## 🎯 결과
- `cse.cau.ac.kr`가 일시 장애여도 `swedu.cau.ac.kr`가 성공하면 메일 발송 유지
- 모든 소스 실패 시 즉시 종료하지 않고 재시도 후 최종 실패 처리
- 운영 중 외부 사이트 불안정성에 대한 복원력 향상

---

## 테스트
- 로컬에서 `npm run start` 실행
- 학부 보드 실패 + SW교육원 성공 상황에서 메일 정상 발송 확인
- 로그로 성공/실패 소스 분리 출력 확인